### PR TITLE
release: v1.2.0

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,10 +1,14 @@
-name: Release-pypi
+name: Release
 
 on:
   workflow_dispatch:
 
+  push:
+    tags:
+      - "v*"
+
 jobs:
-  Pypi:
+  pypi:
     strategy:
       matrix:
         python-version: ["3.9"]
@@ -32,3 +36,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API }}
+
+  github:
+    needs: [pypi]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Release
+        uses: softprops/action-gh-release@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ license = "GPL-3.0-only"
 name = "yuisub"
 readme = "README.md"
 repository = "https://github.com/TensoRaws/yuisub"
-version = "1.1.2"
+version = "1.2.0"
 
 # Requirements
 [tool.poetry.dependencies]

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -7,6 +7,24 @@ from yuisub.translator import SubtitleTranslator
 from . import util
 
 
+def test_translator_sub_init() -> None:
+    translator = SubtitleTranslator(
+        torch_device=util.DEVICE,
+        whisper_model=util.MODEL_NAME,
+        model=util.OPENAI_MODEL,
+        api_key=util.OPENAI_API_KEY,
+        base_url=util.OPENAI_BASE_URL,
+        bangumi_url=util.BANGUMI_URL,
+        bangumi_access_token=util.BANGUMI_ACCESS_TOKEN,
+    )
+
+    assert translator.model == util.OPENAI_MODEL
+    assert translator.api_key == util.OPENAI_API_KEY
+    assert translator.base_url == util.OPENAI_BASE_URL
+    assert translator.bangumi_url == util.BANGUMI_URL
+    assert translator.bangumi_access_token == util.BANGUMI_ACCESS_TOKEN
+
+
 @pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS") == "true", reason="Skipping test when running on CI")
 async def test_translator_sub() -> None:
     translator = SubtitleTranslator(


### PR DESCRIPTION
## Summary by Sourcery

Update the release workflow to trigger on tag pushes and add a GitHub release job. Bump the project version to v1.2.0 and introduce a new test for SubtitleTranslator initialization.

CI:
- Update CI workflow to trigger on tag pushes with pattern 'v*'.

Tests:
- Add a new test for SubtitleTranslator initialization to verify model and API configurations.