### PR TITLE
ci: update CI-test

### DIFF
--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -40,10 +40,8 @@ jobs:
         with:
           poetry-version: ${{ matrix.poetry-version }}
 
-      - uses: FedericoCarboni/setup-ffmpeg@v3
-        id: setup-ffmpeg
-        with:
-          ffmpeg-version: release
+      - name: Setup FFmpeg
+        uses: AnimMouse/setup-ffmpeg@v1
 
       - name: Test
         run: |

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -22,7 +22,7 @@ jobs:
   CI:
     strategy:
       matrix:
-        os-version: ["ubuntu-20.04", "windows-latest", "macos-13"]
+        os-version: ["ubuntu-20.04", "windows-latest", "macos-14"]
         python-version: ["3.9"]
         poetry-version: ["1.8.3"]
 

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test
         run: |
           pip install numpy==1.26.4
-          pip install pre-commit pytest mypy ruff types-requests pytest-cov pytest-asyncio coverage pydantic openai openai-whisper httpx tenacity pysubs2
+          poetry install
 
           make lint
           make test


### PR DESCRIPTION
## Summary by Sourcery

Update CI to use macOS 14 and AnimMouse/setup-ffmpeg@v1 action.

CI:
- Update the CI test matrix to use macOS 14 instead of macOS 13.
- Use AnimMouse/setup-ffmpeg@v1 action instead of FedericoCarboni/setup-ffmpeg@v3 and remove the explicit installation of numpy and other testing dependencies.